### PR TITLE
Error if internalPath does not match archive contents

### DIFF
--- a/archive.go
+++ b/archive.go
@@ -136,6 +136,10 @@ func Unzip(ctx context.Context, dst, src string) (err error) {
 		}
 	}
 
+	if internalPath != "" && len(dirs) == 0 && len(files) == 0 && len(symlinks) == 0 {
+		return fmt.Errorf("astikit: content in archive does not match specified internal path %s", internalPath)
+	}
+
 	// Create dirs
 	for p, f := range dirs {
 		if err = os.MkdirAll(p, f.FileInfo().Mode().Perm()); err != nil {


### PR DESCRIPTION
Return an error if `internalPath` is specified and the archive contents do
not match the `internalPath`. Without this check, if there are no contents
which match the `internalPath`, an empty `dst` directory is produced.

The original behavior resulted in an error like this `Unable to find Electron app at .../linux-amd64/vendor/astilectron/main.js` because a non-matching version of `astilecron.zip` was embedded in the binary (due to a now-fixed problem with our build setup).

I don't know of all of the uses of `astikit.Unzip`, so it's possible that this functionality was intentional and is in use elsewhere. But I was surprised by the lack of error, hence the PR.