### PR TITLE
Return empty string if Slice field from FlagStrings is nil

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -31,6 +31,9 @@ func NewFlagStrings() FlagStrings {
 
 // String implements the flag.Value interface
 func (f FlagStrings) String() string {
+	if f.Slice == nil {
+		return ""
+	}
 	return strings.Join(*f.Slice, ",")
 }
 


### PR DESCRIPTION
In go, when parsing flags and calling `Usage`, `flag.Parse` can use an empty `FlagStrings` struct.  
When calling the `String` method on it, this result on a nil pointer dereference.

To test the wrong behaviour, execute `astisub --help` - the program crashes.

This fix permits to check if the `Slice` field is not nil before concatenate arguments.  
If the field is nil, return an empty string.

Executing `astisub --help` using this fix avoids the crash.