### PR TITLE
BitsWriter: WriteN bugfix; Write and WriteN zero allocation and optimizations

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -3,7 +3,6 @@ package astikit
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -142,12 +141,27 @@ func (w *BitsWriter) writeBit(bit byte) error {
 
 // WriteN writes the input into n bits
 func (w *BitsWriter) WriteN(i interface{}, n int) error {
-	switch i.(type) {
-	case uint8, uint16, uint32, uint64:
-		return w.Write(fmt.Sprintf(fmt.Sprintf("%%.%db", n), i))
+	var toWrite uint64
+	switch a := i.(type) {
+	case uint8:
+		toWrite = uint64(a)
+	case uint16:
+		toWrite = uint64(a)
+	case uint32:
+		toWrite = uint64(a)
+	case uint64:
+		toWrite = a
 	default:
 		return errors.New("astikit: invalid type")
 	}
+
+	for i := n - 1; i >= 0; i-- {
+		err := w.writeBit(byte(toWrite>>i) & 0x1)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 var byteHamming84Tab = [256]uint8{

--- a/binary_test.go
+++ b/binary_test.go
@@ -2,6 +2,7 @@ package astikit
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -78,6 +79,36 @@ func TestBitsWriter(t *testing.T) {
 	}
 	if e, g := []byte{136, 0}, bw.Bytes(); !reflect.DeepEqual(e, g) {
 		t.Errorf("expected %+v, got %+v", e, g)
+	}
+}
+
+func BenchmarkBitsWriter(b *testing.B) {
+	benchmarks := []struct {
+		input interface{}
+	}{
+		{"000000"},
+		{false},
+		{true},
+		{[]byte{2, 3}},
+		{uint8(4)},
+		{uint16(5)},
+		{uint32(6)},
+		{uint64(7)},
+		{1},
+	}
+
+	bw := &bytes.Buffer{}
+	bw.Grow(1024)
+	w := NewBitsWriter(BitsWriterOptions{Writer: bw})
+
+	for _, bm := range benchmarks {
+		b.Run(fmt.Sprintf("%#v", bm.input), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				bw.Reset()
+				w.Write(bm.input)
+			}
+		})
 	}
 }
 

--- a/binary_test.go
+++ b/binary_test.go
@@ -94,7 +94,6 @@ func BenchmarkBitsWriter(b *testing.B) {
 		{uint16(5)},
 		{uint32(6)},
 		{uint64(7)},
-		{1},
 	}
 
 	bw := &bytes.Buffer{}


### PR DESCRIPTION
I am currently working on adding muxer to go-astits. And I'd like to use BitsWriter to serialize TS packets. However, BitsWriter was written to use in tests so the implementation is suboptimal for production use.

So I've done two things.

First, there was a bug in BitsWriter.WriteN function: `fmt.Sprintf("%.Nb")` doesn't work as expected. Consider the following link: https://play.golang.org/p/S-xHcUTJ9_h . As seen there, trying to print 3 bits of `uint8(8)` produces output of `1000`, which is actually 4 bits. As I understand, WriteN is expected to trim any value to number of bits passed to it. Test has been fixed as well.

Second, I've optimized Write and WriteN functions to run faster and make no allocations. Benchmark evidence follows. Benchmarks were ran on MacBook Air M1 under Rosetta, go version go1.16beta1 darwin/arm64.

BitsWriter.Write before optimization:

```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astikit
BenchmarkBitsWriter_Write/000000-8         	16509066	        69.50 ns/op	      48 B/op	       3 allocs/op
BenchmarkBitsWriter_Write/false-8          	81875634	        14.40 ns/op	       8 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/true-8           	45056672	        25.62 ns/op	       8 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/[2_3]-8          	 2895354	       407.9 ns/op	     160 B/op	      11 allocs/op
BenchmarkBitsWriter_Write/4-8              	 6351853	       186.6 ns/op	      72 B/op	       5 allocs/op
BenchmarkBitsWriter_Write/5-8              	 4053002	       294.2 ns/op	     144 B/op	       9 allocs/op
BenchmarkBitsWriter_Write/6-8              	 2496069	       477.8 ns/op	     288 B/op	      17 allocs/op
BenchmarkBitsWriter_Write/7-8              	 1396011	       854.3 ns/op	     576 B/op	      33 allocs/op
PASS
```

BitsWriter.Write after optimization:

```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astikit
BenchmarkBitsWriter_Write/"000000"-8         	61780568	        19.58 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/false-8            	242806110	         4.848 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/true-8             	246064526	         4.880 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/[]byte{0x2,_0x3}-8 	64124545	        18.31 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/0x4-8              	100000000	        10.18 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/0x5-8              	58840713	        20.42 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/0x6-8              	33606070	        35.08 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_Write/0x7-8              	16914987	        71.99 ns/op	       0 B/op	       0 allocs/op
PASS
```

BitsWriter.WriteN before optimization:

```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astikit
BenchmarkBitsWriter_WriteN/0xff/1-8         	 6700066	       155.9 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/2-8         	 7647550	       157.2 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/3-8         	 7540482	       157.4 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/4-8         	 7629554	       158.0 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/5-8         	 6911882	       156.9 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/6-8         	 7593153	       155.1 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/7-8         	 7685973	       156.1 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xff/8-8         	 7602426	       157.0 ns/op	      16 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/1-8       	 6325714	       187.4 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/2-8       	 6448512	       187.3 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/3-8       	 6350730	       188.8 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/4-8       	 6380467	       187.8 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/5-8       	 6356004	       187.0 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/6-8       	 6389172	       187.5 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/7-8       	 6391270	       187.5 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/8-8       	 6347876	       187.8 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/9-8       	 6357808	       187.4 ns/op	      20 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/10-8      	 6259242	       190.0 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/11-8      	 6253765	       189.8 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/12-8      	 6254667	       190.1 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/13-8      	 6269766	       190.3 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/14-8      	 6268303	       190.6 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/15-8      	 6259731	       191.0 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/16-8      	 6290343	       191.4 ns/op	      21 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/1-8   	 4815242	       249.4 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/2-8   	 4798063	       249.5 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/3-8   	 4811362	       249.2 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/4-8   	 4829851	       248.1 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/5-8   	 4813514	       249.5 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/6-8   	 4863276	       249.5 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/7-8   	 4828254	       249.3 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/8-8   	 4802421	       249.3 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/9-8   	 4840605	       249.9 ns/op	      36 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/10-8  	 4764672	       250.8 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/11-8  	 4717837	       251.8 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/12-8  	 4777326	       251.8 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/13-8  	 4775190	       252.1 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/14-8  	 4736322	       251.3 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/15-8  	 4773319	       251.3 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/16-8  	 4763534	       251.7 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/17-8  	 4750508	       252.1 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/18-8  	 4779086	       251.8 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/19-8  	 4769659	       251.8 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/20-8  	 4770170	       251.2 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/21-8  	 4735008	       251.9 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/22-8  	 4738922	       252.3 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/23-8  	 4744203	       252.5 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/24-8  	 4749480	       251.9 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/25-8  	 4768444	       251.0 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/26-8  	 4777770	       250.2 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/27-8  	 4755622	       251.6 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/28-8  	 4762876	       250.5 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/29-8  	 4763703	       251.4 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/30-8  	 4764807	       251.6 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/31-8  	 4776896	       252.6 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/32-8  	 4774111	       251.6 ns/op	      37 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/1-8         	 3341118	       359.0 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/2-8         	 3330296	       359.0 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/3-8         	 3339440	       360.0 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/4-8         	 3323757	       361.1 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/5-8         	 3312913	       361.4 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/6-8         	 3313122	       361.8 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/7-8         	 3315684	       360.5 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/8-8         	 3315918	       361.3 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/9-8         	 3348086	       359.4 ns/op	      68 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/10-8        	 3313999	       361.7 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/11-8        	 3316069	       361.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/12-8        	 3307602	       361.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/13-8        	 3322334	       365.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/14-8        	 3283429	       365.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/15-8        	 3303445	       362.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/16-8        	 3302920	       362.7 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/17-8        	 3313245	       362.2 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/18-8        	 3307994	       361.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/19-8        	 3309344	       361.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/20-8        	 3304630	       361.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/21-8        	 3298186	       362.1 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/22-8        	 3306919	       362.2 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/23-8        	 3293217	       362.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/24-8        	 3319300	       362.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/25-8        	 3300246	       364.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/26-8        	 3291129	       380.5 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/27-8        	 3284038	       368.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/28-8        	 3260071	       377.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/29-8        	 3271530	       368.5 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/30-8        	 3190233	       373.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/31-8        	 3180048	       377.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/32-8        	 3297746	       372.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/33-8        	 3292174	       367.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/34-8        	 3239022	       363.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/35-8        	 3304276	       366.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/36-8        	 3298452	       371.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/37-8        	 3286168	       365.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/38-8        	 3275763	       367.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/39-8        	 3292840	       361.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/40-8        	 3320001	       361.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/41-8        	 3300981	       362.3 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/42-8        	 3308806	       362.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/43-8        	 3306722	       362.7 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/44-8        	 3305413	       362.1 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/45-8        	 3309440	       362.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/46-8        	 3302378	       365.3 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/47-8        	 3306988	       363.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/48-8        	 3302817	       362.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/49-8        	 3288984	       368.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/50-8        	 3265010	       365.7 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/51-8        	 3286570	       364.5 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/52-8        	 3151683	       366.9 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/53-8        	 3267477	       366.4 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/54-8        	 3273426	       366.0 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/55-8        	 3276453	       366.3 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/56-8        	 3291361	       365.1 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/57-8        	 3297312	       368.1 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/58-8        	 3267415	       367.2 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/59-8        	 3316428	       362.1 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/60-8        	 3313537	       361.8 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/61-8        	 3312860	       361.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/62-8        	 3314174	       361.7 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/63-8        	 3311892	       361.6 ns/op	      69 B/op	       2 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/64-8        	 3317235	       361.6 ns/op	      69 B/op	       2 allocs/op
PASS
```

BitsWriter.WriteN after optimization:

```
goos: darwin
goarch: arm64
pkg: github.com/asticode/go-astikit
BenchmarkBitsWriter_WriteN/0xff/1-8         	206328570	         5.601 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/2-8         	135912871	         8.565 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/3-8         	100000000	        11.26 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/4-8         	86527801	        13.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/5-8         	71405546	        17.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/6-8         	61171560	        19.56 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/7-8         	52995925	        22.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xff/8-8         	48251955	        24.84 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/1-8       	214130134	         5.601 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/2-8       	142908876	         8.391 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/3-8       	100000000	        11.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/4-8       	81594952	        14.05 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/5-8       	70528422	        17.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/6-8       	60692528	        19.50 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/7-8       	52872363	        22.32 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/8-8       	47952846	        25.04 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/9-8       	40580812	        28.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/10-8      	38841026	        31.33 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/11-8      	35629496	        35.23 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/12-8      	32634301	        36.54 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/13-8      	30613058	        40.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/14-8      	27217544	        42.18 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/15-8      	26209099	        44.58 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffff/16-8      	24591381	        48.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/1-8   	212488054	         5.581 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/2-8   	143424144	         8.537 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/3-8   	100000000	        11.36 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/4-8   	83975053	        14.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/5-8   	71631453	        17.86 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/6-8   	60745908	        19.67 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/7-8   	53092058	        22.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/8-8   	48215846	        25.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/9-8   	41356432	        28.47 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/10-8  	38842807	        31.27 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/11-8  	32002062	        36.71 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/12-8  	32453702	        38.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/13-8  	30409803	        39.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/14-8  	28516233	        42.51 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/15-8  	26715446	        45.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/16-8  	24651138	        48.52 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/17-8  	23459282	        50.98 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/18-8  	22272954	        53.85 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/19-8  	21086572	        56.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/20-8  	20094008	        59.61 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/21-8  	17656892	        65.39 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/22-8  	17442673	        68.42 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/23-8  	16100052	        74.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/24-8  	16547226	        70.53 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/25-8  	14958598	        82.66 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/26-8  	14477905	        82.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/27-8  	13946500	        88.83 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/28-8  	13605936	        88.72 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/29-8  	13092735	        91.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/30-8  	12751459	        94.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/31-8  	11999614	        97.11 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffff/32-8  	11531770	       104.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/1-8         	210185823	         5.704 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/2-8         	140603469	         8.535 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/3-8         	100000000	        11.40 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/4-8         	80244075	        14.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/5-8         	71203411	        17.85 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/6-8         	58759441	        20.08 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/7-8         	52936310	        22.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/8-8         	46822948	        25.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/9-8         	42215119	        28.48 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/10-8        	37014759	        31.37 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/11-8        	35022435	        34.14 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/12-8        	32420019	        37.11 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/13-8        	30004687	        39.74 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/14-8        	28162623	        42.58 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/15-8        	25606122	        45.39 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/16-8        	24919314	        49.90 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/17-8        	23610891	        51.07 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/18-8        	22158550	        53.91 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/19-8        	21072487	        58.82 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/20-8        	20129400	        59.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/21-8        	18263866	        66.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/22-8        	17374213	        68.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/23-8        	15637810	        75.21 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/24-8        	16260300	        71.12 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/25-8        	14984274	        81.02 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/26-8        	13748210	        83.18 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/27-8        	13941006	        86.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/28-8        	13557776	        89.76 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/29-8        	12860276	        95.64 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/30-8        	12680889	        94.81 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/31-8        	11889196	        97.87 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/32-8        	11892378	       100.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/33-8        	11626389	       104.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/34-8        	11281663	       106.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/35-8        	10900188	       109.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/36-8        	10184656	       112.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/37-8        	10472982	       114.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/38-8        	 9731472	       118.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/39-8        	 9742466	       120.2 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/40-8        	 9711837	       123.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/41-8        	 9227864	       125.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/42-8        	 9288922	       129.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/43-8        	 9117810	       132.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/44-8        	 8975670	       134.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/45-8        	 8720884	       136.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/46-8        	 8567194	       140.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/47-8        	 8419924	       148.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/48-8        	 8234031	       145.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/49-8        	 7824370	       154.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/50-8        	 7637870	       151.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/51-8        	 7803188	       154.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/52-8        	 7325164	       162.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/53-8        	 7501618	       160.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/54-8        	 7118899	       165.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/55-8        	 7240777	       172.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/56-8        	 6806404	       169.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/57-8        	 7029891	       170.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/58-8        	 6908940	       173.6 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/59-8        	 6813783	       176.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/60-8        	 6686109	       179.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/61-8        	 6547536	       183.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/62-8        	 6481606	       193.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/63-8        	 6309711	       196.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkBitsWriter_WriteN/0xffffffffffffffff/64-8        	 6294814	       197.6 ns/op	       0 B/op	       0 allocs/op
```

(Sorry for the long output)