### PR TITLE
BitsWriterBatch added

### DIFF
--- a/binary_test.go
+++ b/binary_test.go
@@ -96,26 +96,23 @@ func (t *testLimitedWriter) Write(p []byte) (n int, err error) {
 	return len(p) + t.BytesLimit, io.EOF
 }
 
-func TestBitsWriter_TryFuncs(t *testing.T) {
+func TestNewBitsWriterBatch(t *testing.T) {
 	wr := &testLimitedWriter{BytesLimit: 1}
 	w := NewBitsWriter(BitsWriterOptions{Writer: wr})
+	b := NewBitsWriterBatch(w)
 
-	w.TryWrite(uint8(0))
-	if err := w.TryErr(); err != nil {
+	b.Write(uint8(0))
+	if err := b.Err(); err != nil {
 		t.Errorf("expected no error, got %+v", err)
 	}
-	w.TryWrite(uint8(1))
-	if err := w.TryErr(); err == nil {
+	b.Write(uint8(1))
+	if err := b.Err(); err == nil {
 		t.Errorf("expected error, got %+v", err)
 	}
 
-	wr.BytesLimit = 1
-	w.TryWrite(uint8(2))
-	if err := w.TryErr(); err != nil {
-		t.Errorf("expected no error, got %+v", err)
-	}
-	w.TryWrite(uint8(3))
-	if err := w.TryErr(); err == nil {
+	// let's check if the error is persisted
+	b.Write(uint8(2))
+	if err := b.Err(); err == nil {
 		t.Errorf("expected error, got %+v", err)
 	}
 }


### PR DESCRIPTION
I've introduced `Try*` functions family to BitsWriter. This feature makes it easier to write and read bitstream serialization code, as well as rendering the code less error-prone (i.e. copy-paste mistakes, etc.).
Consider the following example.

Without `Try*` functions:
```
func writePacketHeader(w *astikit.BitsWriter, h *PacketHeader) (int, error) {
	if err := w.Write(h.TransportErrorIndicator); err != nil {
		return 0, err
	}
	if err := w.Write(h.PayloadUnitStartIndicator); err != nil {
		return 0, err
	}
	if err := w.Write(h.TransportPriority); err != nil {
		return 0, err
	}
	if err := w.WriteN(h.PID, 13); err != nil {
		return 0, err
	}
	if err := w.WriteN(h.TransportScramblingControl, 2); err != nil {
		return 0, err
	}
	if err := w.Write(h.HasAdaptationField); err != nil { // adaptation_field_control higher bit
		return 0, err
	}
	if err := w.Write(h.HasPayload); err != nil { // adaptation_field_control lower bit
		return 0, err
	}
	if err := w.WriteN(h.ContinuityCounter, 4); err != nil {
		return 0, err
	}

	return 3, nil
}
```

With `Try*` functions:
```
func writePacketHeader(w *astikit.BitsWriter, h *PacketHeader) (written int, retErr error) {
	w.TryWrite(h.TransportErrorIndicator)
	w.TryWrite(h.PayloadUnitStartIndicator)
	w.TryWrite(h.TransportPriority)
	w.TryWriteN(h.PID, 13)
	w.TryWriteN(h.TransportScramblingControl, 2)
	w.TryWrite(h.HasAdaptationField) // adaptation_field_control higher bit
	w.TryWrite(h.HasPayload)         // adaptation_field_control lower bit
	w.TryWriteN(h.ContinuityCounter, 4)

	return 3, w.TryErr()
}
```