### PR TITLE
BytesIterator: NextBytesNoCopy added

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -39,11 +39,11 @@ func (i *BytesIterator) NextBytes(n int) (bs []byte, err error) {
 	return
 }
 
-// NextBytesFast returns the n next bytes
+// NextBytesNoCopy returns the n next bytes
 // Be careful with this function as it doesn't make a copy of returned data.
 // bs will point to internal BytesIterator buffer.
 // If you need to modify returned bytes or store it for some time, use NextBytes instead
-func (i *BytesIterator) NextBytesFast(n int) (bs []byte, err error) {
+func (i *BytesIterator) NextBytesNoCopy(n int) (bs []byte, err error) {
 	if len(i.bs) < i.offset+n {
 		err = fmt.Errorf("astikit: slice length is %d, offset %d is invalid", len(i.bs), i.offset+n)
 		return

--- a/bytes.go
+++ b/bytes.go
@@ -39,6 +39,20 @@ func (i *BytesIterator) NextBytes(n int) (bs []byte, err error) {
 	return
 }
 
+// NextBytesFast returns the n next bytes
+// Be careful with this function as it doesn't make a copy of returned data.
+// bs will point to internal BytesIterator buffer.
+// If you need to modify returned bytes or store it for some time, use NextBytes instead
+func (i *BytesIterator) NextBytesFast(n int) (bs []byte, err error) {
+	if len(i.bs) < i.offset+n {
+		err = fmt.Errorf("astikit: slice length is %d, offset %d is invalid", len(i.bs), i.offset+n)
+		return
+	}
+	bs = i.bs[i.offset : i.offset+n]
+	i.offset += n
+	return
+}
+
 // Seek seeks to the nth byte
 func (i *BytesIterator) Seek(n int) {
 	i.offset = n

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -24,6 +24,14 @@ func TestBytesIterator(t *testing.T) {
 	if e := []byte("23"); !bytes.Equal(e, bs) {
 		t.Errorf("expected %+v, got %+v", e, bs)
 	}
+	i.Seek(1)
+	bs, err = i.NextBytesFast(2)
+	if err != nil {
+		t.Errorf("expected no error, got %+v", err)
+	}
+	if e := []byte("23"); !bytes.Equal(e, bs) {
+		t.Errorf("expected %+v, got %+v", e, bs)
+	}
 	i.Seek(4)
 	b, err = i.NextByte()
 	if err != nil {

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -25,7 +25,7 @@ func TestBytesIterator(t *testing.T) {
 		t.Errorf("expected %+v, got %+v", e, bs)
 	}
 	i.Seek(1)
-	bs, err = i.NextBytesFast(2)
+	bs, err = i.NextBytesNoCopy(2)
 	if err != nil {
 		t.Errorf("expected no error, got %+v", err)
 	}


### PR DESCRIPTION
In order to optimize a little bit performance of go-astikit demuxer, I've introduced new `NextBytesFast` function to `BytesIterator`. It doesn't allocate and copy returned bytes, which comes in handy in some circumstances (i.e. TS packet header parsing).

What I'm not sure about is function name: I don't really like `NextBytesFast` name, but couldn't come up with a better one.