### PR TITLE
Batch bit operations

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -206,11 +206,11 @@ func (w *BitsWriter) writeBitsN(toWrite uint64, n int) (err error) {
 	for n > 0 {
 		if w.cacheLen == 0 {
 			if n >= 8 {
+				n -= 8
 				w.bsCache[0] = byte(toWrite >> n)
 				if err = w.flushBsCache(); err != nil {
 					return
 				}
-				n -= 8
 			} else {
 				w.cacheLen = uint8(n)
 				w.cache = byte(toWrite << (8 - w.cacheLen))

--- a/binary.go
+++ b/binary.go
@@ -147,10 +147,7 @@ func (w *BitsWriter) writeByteSlice(in []byte) error {
 
 func (w *BitsWriter) writeFullInt(in uint64, len int) error {
 	if w.bo == binary.BigEndian {
-		err := w.writeBitsN(in, len)
-		if err != nil {
-			return err
-		}
+		return w.writeBitsN(in, len*8)
 	} else {
 		for i := 0; i < len; i++ {
 			err := w.writeFullByte(byte(in >> (i * 8)))
@@ -267,12 +264,7 @@ func (w *BitsWriter) WriteN(i interface{}, n int) error {
 		return errors.New("astikit: invalid type")
 	}
 
-	err := w.writeBitsN(toWrite, n)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return w.writeBitsN(toWrite, n)
 }
 
 // BitsWriterBatch allows to chain multiple Write* calls and check for error only once

--- a/binary_test.go
+++ b/binary_test.go
@@ -194,7 +194,7 @@ func BenchmarkBitsWriter_WriteN(b *testing.B) {
 		i interface{}
 		n int
 	}
-	benchmarks := []benchData{}
+	benchmarks := make([]benchData, 0, 128)
 	for i := 1; i <= 8; i++ {
 		benchmarks = append(benchmarks, benchData{uint8(0xff), i})
 	}


### PR DESCRIPTION
Good day!

This pull request introduce more efficient bit operations on chunked data. For example - if we have 24 bit input and 3 bit filled buffer we should process it in 4 operation (5-8-8-3) instead 24. If buffer is empty and we got byte slice input, we should directly pass it to output writer instead per byte processing (callback still work on per byte fashion).
Unfortunately i don't provide you with benchmark data, but in go-astits astits-es-split it gave almost x5 speed up:
```
2022/09/07 10:52:50 Got all PMTs
2022/09/07 10:52:50     Program 1 PCR PID 256
2022/09/07 10:52:50             ES PID 256 type H264 Video
2022/09/07 10:52:50             ES PID 260 type AAC Audio
2022/09/07 10:52:50             ES PID 261 type AAC Audio
2022/09/07 10:52:50 4517828 bytes written at rate 45.01 mb/s
2022/09/07 10:52:50 Done
```
VS
```
2022/09/07 10:55:16 Got all PMTs
2022/09/07 10:55:16     Program 1 PCR PID 256
2022/09/07 10:55:16             ES PID 256 type H264 Video
2022/09/07 10:55:16             ES PID 260 type AAC Audio
2022/09/07 10:55:16             ES PID 261 type AAC Audio
2022/09/07 10:55:16 4517828 bytes written at rate 219.39 mb/s
2022/09/07 10:55:16 Done
```
Also, in our application it drastically reduce CPU utilization on muxing stage. I attach profiling data for same data source/time/load.
![Screenshot_20220905_131003](https://user-images.githubusercontent.com/33830890/188828412-bdca04b5-54ab-4743-926d-3cfbe2892086.png)
![Screenshot_20220905_131937](https://user-images.githubusercontent.com/33830890/188828417-90653366-1909-4aed-82fa-4bffc722a74c.png)
